### PR TITLE
Delete include for diskspd.xsd

### DIFF
--- a/diskspd_vs/XmlProfileParser/XmlProfileParser.vcxproj
+++ b/diskspd_vs/XmlProfileParser/XmlProfileParser.vcxproj
@@ -134,12 +134,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\XmlProfileParser.h" />
-    <ClInclude Include="diskspd.h">
-      <DependentUpon>..\..\XmlProfileParser\diskspd.xsd</DependentUpon>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <Xsd Include="..\..\XmlProfileParser\diskspd.xsd" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\XmlProfileParser\XmlProfileParser.cpp" />


### PR DESCRIPTION
The include for diskspd.xsd isn't required as it's included as a resource in the CmdRequestCreator project.