### PR TITLE
check-vmfleet: add per-vm iops aggregation via qosflow

### DIFF
--- a/Frameworks/VMFleet/check-vmfleet.ps1
+++ b/Frameworks/VMFleet/check-vmfleet.ps1
@@ -29,15 +29,98 @@ param ($group = '*')
 
 $g = Get-ClusterGroup |? GroupType -eq VirtualMachine |? Name -like "vm-$group-*"
 
+
+###########################################################
 write-host -fore green State Pivot
 $g | group -Property State -NoElement | sort -Property Name | ft -autosize
 
+###########################################################
 write-host -fore green Host Pivot
 $g | group -Property OwnerNode,State -NoElement | sort -Property Name | ft -autosize
 
+###########################################################
 write-host -fore green Group Pivot
 $g |% {
     if ($_.Name -match "^vm-([^-]+)-") {
         $_ | add-member -NotePropertyName Group -NotePropertyValue $matches[1] -PassThru
     }
 } | group -Property Group,State -NoElement | sort -Property Name | ft -AutoSize
+
+###########################################################
+write-host -fore green IOPS Pivot
+# build 5 orders of log steps
+$logstep = 10,20,50
+$log = 1
+$logs = 1..5 |% {
+
+    $logstep |% { $_ * $log }
+    $log *= 10
+}
+
+# build log step names; 0 is the > range catchall
+$lognames = @{}
+foreach ($step in $logs) {
+
+    if ($step -eq $logs[0]) {
+        $lognames[$step] = "< $step"
+    } else {
+        $lognames[$step] = "$pstep - $($step - 1)"
+    }
+    $pstep = $step
+}
+$lognames[0] = "> $($logs[-1])"
+
+# now bucket up VMs by flow rates
+$qosbuckets = @{}
+$qosbuckets[0] = 0
+$logs |% {
+    $qosbuckets[$_] = 0
+}
+
+Get-StorageQoSFlow |% {
+    
+    $found = $false
+    foreach ($step in $logs) {
+
+        if ($_.InitiatorIops -lt $step) {
+            $qosbuckets[$step] += 1;
+            $found = $true
+            break
+        }
+    }
+    # if not bucketed, it is greater than range
+    if (-not $found) {
+        $qosbuckets[0] += 1
+    }
+}
+
+# find min/max buckets with nonzero counts, by $logs index
+# this lets us present a continuous range, with interleaved zeroes
+$bmax = -1
+$bmin = -1
+foreach ($i in 0..($logs.Count - 1)) {
+    if ($qosbuckets[$logs[$i]]) {
+    
+        if ($bmin -lt 0) {
+            $bmin = $i
+        }
+        $bmax = $i
+    }
+}
+# raise max if we have > range
+if ($qosbuckets[0]) {
+    $bmax = $logs.Count - 1
+}
+$range = @($logs[$bmin..$bmax])
+# add > range if needed, at end
+if ($qosbuckets[0]) {
+    $range += 0
+}
+
+$(foreach ($i in $range) {
+
+    New-Object -TypeName psobject -Property @{
+        Count = $qosbuckets[$i];
+        IOPS = $lognames[$i]
+    }    
+}) | ft Count,IOPS


### PR DESCRIPTION
create-vmfleet: update vm creation idempotency (better, not perfect)
watch-cluster: new sets for sbl local/remote, smb (client) transport rdma v. total, avgqueue for csvfs, l0/1/2 for cache, trim format for s2dbw
watch-cluster: -cluster switch for remoting, restart sample job every 100 to limit resource growth
watch-cpu: make it work for non-hv systems, don't remote unless neccesary