### PR TITLE
Escape passwords that use special characters.

### DIFF
--- a/Frameworks/VMFleet/launch-template.ps1
+++ b/Frameworks/VMFleet/launch-template.ps1
@@ -26,9 +26,13 @@ SOFTWARE.
 #>
 
 $script = 'c:\run\master.ps1'
+<# prevent password injection errors when password contains ',"",*, etc. #>
+$password = @'
+__CONNECTPASS__
+'@
 
 while ($true) {
     Write-Host -fore Green Launching $script `@ $(Get-Date)
-    & $script -connectuser __CONNECTUSER__ -connectpass __CONNECTPASS__
+    & $script -connectuser __CONNECTUSER__ -connectpass $password
     sleep -Seconds 1
 }


### PR DESCRIPTION
This is a patch for Issue 60: https://github.com/microsoft/diskspd/issues/60
When using a password that replaces __CONNECTPASS__ that has special characters such as ',",* the command on line 36 no longer causes a syntax error.