### PR TITLE
Enable ByNode ParameterSet in New-Fleet

### DIFF
--- a/Frameworks/VMFleet/VMFleet.psm1
+++ b/Frameworks/VMFleet/VMFleet.psm1
@@ -2174,6 +2174,7 @@ function New-Fleet
     switch ($psCmdlet.ParameterSetName)
     {
         "ByCluster" { $Nodes = @(Get-ClusterNode @clusterParam) }
+        "ByNode"    { $Nodes = @(Get-ClusterNode -Name $node) }
     }
 
     # convert to fixed vhd(x) if needed


### PR DESCRIPTION
Added ability to pass a list of nodes in the -Node parameter to the New-Fleet function. The use case is to create separate fleets for each site in a stretched cluster.