### PR TITLE
Adds a new command to generate and set workload profile

### DIFF
--- a/Frameworks/VMFleet/VMFleet.psd1
+++ b/Frameworks/VMFleet/VMFleet.psd1
@@ -125,6 +125,7 @@ FunctionsToExport = @(
     'Set-FleetPowerScheme',
     'Set-FleetProfile',
     'Set-FleetQoS',
+    'Set-FleetRunProfileScript',
     'Show-Fleet',
     'Show-FleetCpuSweep',
     'Show-FleetPause',


### PR DESCRIPTION
Adds a new command Set-FleetRunProfileScript which generates profile.xml and sets run profile template script in SMB directory.
This command will is useful especially for free runs using already available profiles (Peak, SQL, VDI etc) without having to opt into the stepped runs.

# Sample command
```

 $profile = Get-FleetProfileXml -Name "VDI"
 Set-FleetRunProfileScript  -ProfileXml $profile

```
