### PR TITLE
User/danlo/vmfleet 2.0.2.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Use text conventions for commonly used text extensions.
+*.csv text
+*.ini text
+*.json text
+*.txt text
+*.xml text
+*.ps1 text
+*.ps1xml text
+*.psd1 text
+
+
+# Denote all files that are truly binary and should not be modified.
+*.dll binary
+*.exe binary
+*.gz binary
+*.ico binary
+*.jpg binary
+*.lib binary
+*.pdb binary
+*.pdf binary
+*.png binary
+*.wim binary
+*.zip binary

--- a/Frameworks/VMFleet/VMFleet.psd1
+++ b/Frameworks/VMFleet/VMFleet.psd1
@@ -37,7 +37,7 @@ SOFTWARE.
 RootModule = 'VMFleet.psm1'
 
 # Version number of this module. Even build# is release, odd pre-release (Mj.Mn.Bd.Rv)
-ModuleVersion = '2.0.2.2'
+ModuleVersion = '2.0.2.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
minor update

quote through the vm connect-back password so it can contain non-alpha safely
watch-fleetcluster: now allows looking at guest vcpu; same model will eventually allow asserting ~idle before running variations, a current gap
get-doneflags: needs to be able time out during the flag check so that laggy checks don't exceed total runtime
allow flat configurations which did not disable cache; this is fine (e.g., cache enabled but no cache/warmup)
get-performancecounter: now handles dropped samples
ignore reboot required signal when flipping cache on/off