### PR TITLE
Adds support for arc-enabled virtual machines in HCI setup

### DIFF
--- a/Frameworks/VMFleet/ArcVM-Setup.md
+++ b/Frameworks/VMFleet/ArcVM-Setup.md
@@ -1,0 +1,329 @@
+# From Setup to Start-FleetSweep for Arc Enabled Virtual Machines in HCI clusters
+
+This is the traditional path of setting up VMFleet to deploy Arc enabled VMs on HCI clusters and running it using your desired DiskSpd parameters/flags.
+
+ 
+
+## Prerequisites
+
+Before we begin setting up VMFleet, there are a few prerequisites that you should have ready.
+
+Ensure an HCI cluster is setup.
+
+Ensure that you have 1 CSV per node
+
+Within Storage Spaces Direct, CPU usage is based on the host. Therefore, it is recommended that you split the storage load by creating as many CSVs as there are host nodes. We can go ahead and create a CSV per node in the cluster.
+
+You may run the following:
+ 
+
+```
+Get-ClusterNode |% {
+    New-Volume -StoragePoolFriendlyName SU1_Pool* -FriendlyName $_ -FileSystem CSVFS_ReFS -Size <DESIRED SIZE>
+}
+
+``` 
+
+Ensure that you create a “collect” volume.
+
+You may run the following:
+ 
+```
+
+New-Volume -StoragePoolFriendlyName SU1_Pool* -FriendlyName collect -FileSystem CSVFS_ReFS -Size 200GB
+
+``` 
+
+If you have ran VMFleet in the past, please ensure that prior VMFleet directories are completely removed from existing volumes.
+
+Retrieve or install a Server Core VHDX file. If you do not have one handy, we can create a new one by following the below instructions.
+
+Download WS2019 Server Core ISO from the public website.
+
+Open Hyper-V Manager.
+
+Click “New”, then “Virtual Machine”.
+
+Navigate through the prompts and pick a location to store your VM.
+
+Once your VM is created, boot up the VM and follow the instructions. This is where you will decide your VM password, or what we will later call, “adminpass”.
+
+This is important as we will use this later, so make sure you write this down.
+
+Log out of the VM, and navigate to where you stored your VM. You should find a “Virtual Hard Disks” folder. Inside, you should find your new Server Core VHDX file.
+
+Rename it to “Base1.vhdx”.
+
+Copy or move the file to the cluster environment that you want to run VMFleet in.
+
+Done!
+
+### Deployment
+
+1. First, we need to install the new PowerShell Module from the PowerShell Gallery and then load it into our terminal. We also need to disable cache as it is not supported currently for ArcVMs. Run the following:
+ 
+```
+Install-Module -Name “VMFleet”
+Import-Module VMFleet
+Set-ClusterStorageSpacesDirect -CacheState Disabled; 
+ 
+```
+
+
+2. Sanity Check:
+    Run "Get-Module VMFleet" to confirm the module exists.
+
+    Run "Get-Command -Module VMFleet" to obtain a list of functions included in the module.
+
+    We will now set up the directory structure within the “Collect” CSV created earlier. Run "Install-Fleet"
+
+    This creates the necessary VMFleet directories which include:
+
+       * Collect/control
+
+            Contains arc.json which stores Arc configuration and the scripts that the Virtual Machines continuously monitor.
+
+       * Control.ps1: the control script the VMs use to implement the control loop (what used to be called “master.ps1”).
+
+       * Run.ps1: The VMs continuously look for the most recent version of run.ps1 and runs the newly updated script (parameters).
+
+       * Collect/flag
+
+            Location where the control script drops the “go”, “pause”, and “done” flag files. Users should not need to look at these files.
+
+       * Collect/result
+
+            Location of the output files from the VMFleet test run.
+
+       * Collect/tools
+
+            DiskSpd will be preinstalled in this folder.
+
+3. You need to create a new or use existing Resource group under the same subscription as the Resource bridge VM is under. Set-ArcConfig will take care of creating one if not already present.
+
+4. Setup configuration required for creating Arc enabled Virtual Machines.
+
+```
+Set-ArcConfig -ResourceGroup [ENTER_RESOURCE_GROUP] -AzureRegistrationUser [ENTER_AZURE_REGUSER] -AzureRegistrationPassword [ENTER_AZURE_REGPASS]-StoragePathCsv [ENTER_CSV_PATH] -Enabled $true -StoragePathName [ENTER_StoragePath_Name] -ImageName [ENTER_Image_Name]  -ResetSalt
+```
+
+    -"ResourceGroup" is the resource group where ARC VMs will be deployed.
+
+    -"AzureRegistrationUser" and "AzureRegistrationPassword" are the azure account credentials.
+
+    -"StoragePathCsv" (optional) is the csv path where storage path resource will be created. If not provided, one of the existing csvs which were created earlier will be used by default.
+
+    -"StoragePathName" (optional) is the storage path name which will be used to create gallery image. If not provided, default name will be used.
+
+    -"ImageName" (optional) is the gallery image name which will be used to create Arc-enabled virtual machines. If not provided, default name will be used. Currently, only windows gallery image is the supported image type for Arc-Enabled VMs.
+
+    -"Enabled" (optional) is set to $false by default. Set to $true if Arc-enabled virtual machines are to be created.
+
+    -"ResetSalt" (optional) is a flag used to reset salt. Salt is a random 4 character (alphanumeric) used in Arc resource names for arc enabled virtual machines (for eg: vm-group-node-salt-001). In case, user wants to regenerate the salt, they can run "Set-ArcConfig -ResetSalt" which will override existing salt with a new one in the arc.json and this will be used to create new VMs. This is useful in case of multiple clusters under same subscription using same resource group on a virtual setup. A 4 character (alphanumeric) Salt will be generated by default when user runs Set-ArcConfig the first time and stored in arc.json along with other arc configs. Within Set-ArcConfig, a quick test is done to check if atleast one vm exists with same salt in the resource group. If it does, it is regenerated.
+
+5. By default, VMs with 2GB static memory and 1 processor count will be created.
+
+    Note: Please move the VHDX file into the collect folder. CSV Cache is also turned off by default.
+
+    We will now create our “fleet” of VMs by running:
+    
+```
+New-Fleet -basevhd <PATH TO VHDX> -vms [ENTER_NUM_VMS] -adminpass [ENTER_ADMINPASS] -connectuser [ENTER_NODE_USER] -connectpass [ENTER_NODE_PASS]
+``` 
+
+    -"adminpass" is the administrator password for the Server Core Image. This is the password you set on your Virtual Machine earlier.
+
+    -"connectuser" is a domain account with access to the cluster.
+
+    -"connectpass " is the password for the above domain account.
+
+    -"vms" is the number of VM's to create per node.
+
+6. If "vms" parameter is not provided, the default is a 1:1 subscription ratio where the Number of VMs = Number of physical cores.
+
+[Optional] You can consider modifying the VM hardware configuration. Run
+ 
+```
+Set-Fleet -ProcessorCount 1 -MemoryStartupBytes 2048mb -MemoryMaximumBytes 2048mb -MemoryMinimumBytes 2048mb
+ ```
+
+Note:
+
+If you specify “MemoryMaximumBytes”, you must specify “MemoryMinimumBytes”, which implies that your VMs will have dynamic memory.
+
+If you omit “MemoryMaximumBytes” or “MemoryMinimumBytes”, it implies that your VMs will have static memory.
+
+If MemoryStartupBytes = MemoryMinimumBytes = MemoryMaximumBytes, that also denotes static memory.
+
+“MemoryStartupBytes” is a mandatory parameter.
+
+
+### Start Running VMFleet!
+
+7. Open 2 PowerShell terminals. In the first one, run Watch-Cluster and in the second one, run Start-Fleet. This second function will turn on all the VMs in a “paused” state.
+
+8. At this point you can run Start-FleetSweep [ENTER_PARAMETERS] or take this time to explore and run any of the other functions!
+
+Here is a sample sweep command to help you get started: "Start-FleetSweep -b 4 -t 8 -o 8 -w 0 -d 300 -p r"
+
+9. Done!
+
+### Aftermath
+
+Once you are done running VMFleet you can run Stop-Fleet to shut down all the virtual machines or run Remove-Fleet to completely delete all the virtual machines on your environment.
+
+# From Setup to Measure-FleetCoreWorkload
+
+This is a new workflow for setting up VMFleet and the predefined profile workloads (General, Peak, VDI, SQL).
+
+ 
+
+## Prerequisites
+
+Before we begin setting up VMFleet, there are a few prerequisites that you should have ready.
+
+Ensure an HCI cluster is setup.
+
+Ensure that you have 1 CSV per node
+
+Within Storage Spaces Direct, CPU usage is based on the host. Therefore, it is recommended that you split the storage load by creating as many CSVs as there are host nodes. We can go ahead and create a CSV per node in the cluster.
+
+In order to be precise about the CSV size, please use our new VMFleet command: "Get-FleetVolumeEstimate"
+
+This will output a prescribed CSV size based on different resiliency types. We recommend you select a 2-way mirrored value or 3-way mirrored value depending on your node count.
+
+1. You may run the following: (use the CSV size from Get-FleetVolumeEstimate)
+ 
+```
+Get-ClusterNode |% {
+    New-Volume -StoragePoolFriendlyName SU1_Pool* -FriendlyName $_ -FileSystem CSVFS_ReFS -Size <DESIRED SIZE>
+}
+```
+
+    Ensure that you create a “collect” volume.
+
+2. You may run the following:
+ 
+```
+New-Volume -StoragePoolFriendlyName SU1_Pool* -FriendlyName collect -FileSystem CSVFS_ReFS -Size 200GB
+``` 
+
+3. If you have ran VMFleet in the past, please ensure that prior VMFleet directories are completely removed from existing volumes.
+
+    Retrieve or install a Server Core VHDX file. If you do not have one handy, we can create a new one by following the below instructions.
+
+    Download WS2019 Server Core ISO from the public website.
+
+    Open Hyper-V Manager.
+
+    Click “New”, then “Virtual Machine”.
+
+    Navigate through the prompts and pick a location to store your VM.
+
+    Once your VM is created, boot up the VM and follow the instructions. This is where you will decide your VM password, or what we will later call, “adminpass”.
+
+    This is important as we will use this later, so make sure you write this down.
+
+    Log out of the VM, and navigate to where you stored your VM. You should find a “Virtual Hard Disks” folder. Inside, you should find your new Server Core VHDX file.
+    Rename it to “Base1.vhdx”.
+
+    Copy or move the file to the cluster environment that you want to run VMFleet in.
+
+4. Done!
+
+## Deployment
+5. Let’s begin deploying VMFleet. First, we need to install the new PowerShell Module from the PowerShell Gallery and then load it into the terminal. Run the following:
+ 
+```
+Install-Module -Name “VMFleet”
+Import-Module VMFleet
+Set-ClusterStorageSpacesDirect -CacheState Disabled; 
+```
+
+ 
+
+## Sanity Check:
+
+6. Run "Get-Module VMFleet" to confirm the module exists.
+
+7. Run "Get-Command -Module VMFleet" to obtain a list of commands included in the module.
+
+8. We will now set up the directory structure within the “Collect” CSV that we created earlier. Run "Install-Fleet"
+
+9. You need to create a new or use existing Resource group under the same subscription as the Resource bridge VM is under. Set-ArcConfig will take care of creating one if not already present.
+
+10. Setup configuration required for creating Arc enabled Virtual Machines.
+
+```
+Set-ArcConfig -ResourceGroup [ENTER_RESOURCE_GROUP] -AzureRegistrationUser [ENTER_AZURE_REGUSER] -AzureRegistrationPassword [ENTER_AZURE_REGPASS]-StoragePathCsv [ENTER_CSV_PATH] -Enabled $true -StoragePathName [ENTER_StoragePath_Name] -ImageName [ENTER_Image_Name]  -ResetSalt
+```
+
+    -"ResourceGroup" is the resource group where ARC VMs will be deployed.
+
+    -"AzureRegistrationUser" and "AzureRegistrationPassword" are the azure account credentials.
+
+    -"StoragePathCsv" (optional) is the csv path where storage path resource will be created. If not provided, one of the existing csvs which were created earlier will be used by default.
+
+    -"StoragePathName" (optional) is the storage path name which will be used to create gallery image. If not provided, default name will be used.
+
+    -"ImageName" (optional) is the gallery image name which will be used to create Arc-enabled virtual machines. If not provided, default name will be used.
+
+    -"Enabled" (optional) is set to $false by default. Set to $true if Arc-enabled virtual machines are to be created.
+
+    -"ResetSalt" (optional) is a flag used to reset salt. Salt is a random 4 character (alphanumeric) used in Arc resource names for arc enabled virtual machines (for eg: vm-group-node-salt-001). In case, user wants to regenerate the salt, they can run "Set-ArcConfig -ResetSalt" which will override existing salt with a new one in the arc.json and this will be used to create new VMs. This is useful in case of multiple clusters under same subscription using same resource group on a virtual setup. A 4 character (alphanumeric) Salt will be generated by default when user runs Set-ArcConfig the first time and stored in arc.json along with other arc configs. Within Set-ArcConfig, a quick test is done to check if atleast one vm exists with same salt in the resource group. If it does, it is regenerated.
+
+11. By default, VMs with 2GB static memory and 1 processor count will be created.
+
+    Note: Please move the VHDX file into the collect folder. CSV Cache is also turned off by default.
+
+    We will now create our “fleet” of VMs by running:
+    
+```
+New-Fleet -basevhd <PATH TO VHDX> -vms [ENTER_NUM_VMS] -adminpass [ENTER_ADMINPASS] -connectuser [ENTER_NODE_USER] -connectpass [ENTER_NODE_PASS]
+``` 
+
+    -"adminpass" is the administrator password for the Server Core Image. This is the password you set on your Virtual Machine earlier.
+
+    -"connectuser" is a domain account with access to the cluster.
+
+    -"connectpass " is the password for the above domain account.
+
+    -"vms" is the number of VM's to create per node.
+
+
+12. Measure-FleetCoreWorkload also collects diagnostic data (Get-SDDCDiagnosticInfo). Therefore, before running the command, we must also install the NuGet Package if you have not previously done so. In doing so, we also need to temporairly set the PSGallery as a trusted repository source (Note: This will temporarily relax the security boundary). 
+
+ 
+```
+$repo = Get-PSRepository -Name PSGallery
+if ($null -eq $repo) { Write-Host "The PSGallery is not configured on this system, please address this before continuing" }
+else {
+    if ($repo.InstallationPolicy -ne 'Trusted') {
+        Write-Host "Setting the PSGallery repository to Trusted, original InstallationPolicy: $($repo.InstallationPolicy)"
+        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+    } 
+
+    ### Installing the pre-requisite modules
+
+    Install-PackageProvider NuGet -Force
+    Install-Module -Name PrivateCloud.DiagnosticInfo -Force
+    Install-Module -Name MSFT.Network.Diag -Force
+
+    if ($repo.InstallationPolicy -ne 'Trusted') {
+        Write-Host "Resetting the PSGallery repository to $($repo.InstallationPolicy)"
+        Set-PSRepository -Name PSGallery -InstallationPolicy $repo.InstallationPolicy
+    } 
+}  
+``` 
+
+## Run Measure-FleetCoreWorkload!
+13. We can now run Measure-FleetCoreWorkload. Running the command below will automatically run all 4 workloads (General, Peak, VDI, SQL) and place the individual outputs in the result directory. IMPORTANT: If you plan on running another test, please clear the result directory.
+
+ 
+```
+Measure-FleetCoreWorkload
+``` 
+
+14. Congratulations! You’re done! All you need to do is wait for the test to complete.
+
+Note: If you ever run into an error and need to rerun Measure-FleetCoreWorkload, don’t be afraid to do so! It is smart enough to pick up from where it last stopped and continue the test without starting from scratch.

--- a/Frameworks/VMFleet/VMFleet.psd1
+++ b/Frameworks/VMFleet/VMFleet.psd1
@@ -120,11 +120,13 @@ FunctionsToExport = @(
     'New-Fleet',
     'Remove-Fleet',
     'Repair-Fleet',
+    'Set-ArcConfig',
     'Set-Fleet',
     'Set-FleetPause',
     'Set-FleetPowerScheme',
     'Set-FleetProfile',
     'Set-FleetQoS',
+    'Set-FleetRunProfileScript',
     'Show-Fleet',
     'Show-FleetCpuSweep',
     'Show-FleetPause',
@@ -138,7 +140,8 @@ FunctionsToExport = @(
     'Test-FleetResultRun',
     'Use-FleetPolynomialFit',
     'Watch-FleetCluster',
-    'Watch-FleetCPU'
+    'Watch-FleetCPU',
+    'Initialize-ArcVMs'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Frameworks/VMFleet/VMFleet.psm1
+++ b/Frameworks/VMFleet/VMFleet.psm1
@@ -1273,6 +1273,162 @@ $CommonFunc = {
             [pscustomobject] $props
         }
     }
+
+    # Initializes Archci configs and retrieves extended location required for resource creation using Azure CLI
+    function InitializeAndGetArcHCIExtendedLoc($azUser, $azPassword, $resourceGroup) {
+        az config set extension.use_dynamic_install=yes_without_prompt core.encrypt_token_cache=false core.disable_confirm_prompt=true core.only_show_errors=true;
+        $subscription = ((Get-AzureStackHCI | select AzureResourceUri).AzureResourceUri).Split("/")[2]
+        $location = (Get-AzureStackHCI | select Region).Region
+        $isLoggedIn = az login -u $azUser -p $azPassword
+        if($isLoggedIn -eq $null){
+           throw "Azure login failed with error - $isLoggedIn"
+        }
+        az account set -s $subscription
+        try{
+           $groupResult = az group show --name $resourceGroup | ConvertFrom-Json
+            if ($groupResult.properties.provisioningState -eq "Succeeded") {
+                Write-Host "Resource group $resourceGroup already exists"
+            }
+            else {
+                 Write-Host "Creating new Resource group $resourceGroup ..."
+                 az group create --name $resourceGroup --location $location             
+            }
+        $rbResourceGroup = ((Get-AzureStackHCI | select AzureResourceUri).AzureResourceUri).Split("/")[4]
+        $customLocationResult = az customlocation list --resource-group $rbResourceGroup  | ConvertFrom-Json
+        $extendedLocation = $customLocationResult[0].id # by default uses the first available custom location
+        }
+        catch{
+            throw $_.Exception.Message
+        }
+        return $extendedLocation
+    }
+
+    function ApplySpecialization( $path, $vmspec, $admin, $adminPass, $connectUser, $connectPass ) {
+        # all steps here can fail immediately without cleanup
+
+        # error accumulator
+        $ok = $true
+
+        # create run directory
+
+        Remove-Item -Recurse -Force z:\run -ErrorAction SilentlyContinue
+        mkdir z:\run
+        $ok = $ok -band $?
+        if (-not $ok) {
+            Write-Error "failed run directory creation for $vhdpath"
+            return $ok
+        }
+
+        # autologon
+        $null = reg load 'HKLM\tmp' z:\windows\system32\config\software
+        $ok = $ok -band $?
+        $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v DefaultUserName /t REG_SZ /d $admin
+        $ok = $ok -band $?
+        $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v DefaultPassword /t REG_SZ /d $adminPass
+        $ok = $ok -band $?
+        $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v AutoAdminLogon /t REG_DWORD /d 1
+        $ok = $ok -band $?
+        $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v Shell /t REG_SZ /d 'powershell.exe -noexit -command C:\users\administrator\launch.ps1'
+        $ok = $ok -band $?
+
+        $null = reg unload 'HKLM\tmp'
+        $ok = $ok -band $?
+        if (-not $ok) {
+            Write-Error "failed autologon injection for $vhdpath"
+            return $ok
+        }
+
+        # scripts
+
+        Copy-Item -Force C:\ClusterStorage\collect\control\control.ps1 z:\run\control.ps1
+        $ok = $ok -band $?
+        if (-not $ok) {
+            Write-Error "failed injection of specd master.ps1 for $vhdpath"
+            return $ok
+        }
+
+        #
+        # Wrapper for the controller script to auto-restart on failure/update.
+        # This is the autologin script itself.
+        #
+        function Set-FleetLauncherScript {
+            $script = 'C:\run\control.ps1'
+
+            while ($true) {
+                Write-Host -fore Green Launching $script `@ $(Get-Date)
+                try { & $script -connectuser __CONNECTUSER__ -connectpass '__CONNECTPASS__' } catch {}
+                Start-Sleep -Seconds 1
+            }
+        }
+
+        Remove-Item -Force z:\users\administrator\launch.ps1 -ErrorAction SilentlyContinue
+        (Get-Command Set-FleetLauncherScript).ScriptBlock | % {
+           $_ -replace '__CONNECTUSER__',$connectUser -replace '__CONNECTPASS__',$connectPass
+        } > z:\users\administrator\launch.ps1
+        $ok = $ok -band $?
+        if (-not $ok) {
+            Write-Error "failed injection of launch.ps1 for $vhdpath"
+            return $ok
+        }
+
+        Write-Output $vmspec > z:\vmspec.txt
+        $ok = $ok -band $?
+        if (-not $ok) {
+            Write-Error "failed injection of vmspec for $vhdpath"
+            return $ok
+        }
+
+        # load files
+        $f = 'z:\run\testfile1.dat'
+        if (-not (Get-Item $f -ErrorAction SilentlyContinue)) {
+            fsutil file createnew $f (10GB)
+            $ok = $ok -band $?
+            fsutil file setvaliddata $f (10GB)
+            $ok = $ok -band $?
+        }
+        if (-not $ok) {
+            Write-Error "failed creation of initial load file for $vhdpath"
+            return $ok
+        }
+
+        return $ok
+    }
+
+    function SpecializeVhd {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $true)][string]$vhdpath,
+            [Parameter(Mandatory = $true)][string]$admin,
+            [Parameter(Mandatory = $true)][string]$adminPass,
+            [Parameter(Mandatory = $true)][string]$connectUser,
+            [Parameter(Mandatory = $true)][string]$connectPass,
+            [Parameter(Mandatory = $false)][string]$name
+        )
+        $ok = $true
+        $vhd = (Get-Item $vhdpath)
+        if ($name) {
+            $vmspec = $name
+        }
+        else {
+            $vmspec = $vhd.BaseName  
+        }
+
+
+        # mount vhd and its largest partition
+        $o = Mount-VHD $vhd -NoDriveLetter -Passthru
+        if ($null -eq $o) {
+            Write-Error "failed mount for $vhdpath"
+            return $false
+        }
+        $p = Get-Disk -number $o.DiskNumber | Get-Partition | Sort-Object -Property size -Descending | Select-Object -first 1
+        $p | Add-PartitionAccessPath -AccessPath Z:
+        $ok = ApplySpecialization Z: $vmspec $admin $adminPass $connectUser $connectPass
+
+        Remove-PartitionAccessPath -AccessPath Z: -InputObject $p
+        Dismount-VHD -DiskNumber $o.DiskNumber
+
+        return $ok
+    }
 }
 
 # Evaluate common block into local session
@@ -2145,6 +2301,27 @@ function New-Fleet
 
     ##################
 
+    # check if Arc enabled VMs should be created
+    $createArcVMs = $false
+    $arcConfig = Get-ArcConfig -Cluster $Cluster
+    $resourceGroup, $azUser, $azPassword, $storagePath, $image, $salt = $null
+    if($arcConfig -and $arcConfig.Enabled){
+       $createArcVMs = $true
+       $resourceGroup, 
+       $azUser, 
+       $azPassword, 
+       $storagePath, 
+       $image, 
+       $salt = 
+       $arcConfig.ResourceGroup, 
+       $arcConfig.AzureRegistrationUser,
+       $arcConfig.AzureRegistrationPassword, 
+       $arcConfig.StoragePathName, 
+       $arcConfig.ImageName, 
+       $arcConfig.Salt
+       LogOutput "Create Arc-enabled Virtual Machines? $createArcVMs"
+    }
+
     # validate existence of BaseVHD
     if (-not (Test-Path -Path $BaseVHD)) {
         $errorObject = CreateErrorRecord -ErrorId "No BaseVHD" `
@@ -2263,259 +2440,335 @@ function New-Fleet
         FriendlyVolumeName = $_.SharedVolumeInfo.FriendlyVolumeName
     }}
 
-    Invoke-CommonCommand $nodes -InitBlock $CommonFunc -ArgumentList @(,$csvs) -ScriptBlock {
+    # Create Gallery Image and Storage Path Arc resources if Arc VM flag set to true
+    if ($createArcVMs) {
+        if(-not ($arcConfig | Get-Member -Name 'StoragePathCsv' -MemberType Properties)){
+            foreach ($csv in $csvs) {
+                # identify the Csv which can be used to create storage path
+                # the trailing characters (if any) are the group prefix
+                if ($csv.VDName -match "^$env:COMPUTERNAME(?:-.+){0,1}") {
+                    $arcConfig | Add-Member -MemberType NoteProperty -Name "StoragePathCsv" -Value $csv.FriendlyVolumeName
+                    $storagePathCsv = $arcConfig.StoragePathCsv
+                    break
+                }
+            }
+        }
+        $result =  Invoke-CommonCommand $nodes[0] -InitBlock $CommonFunc -ArgumentList @($BaseVHD)  -ScriptBlock {  
+            param($vhdPath)
+            $retryCount = 0
+            while ($retryCount -lt 3) {
+                try {
+                    $extendedLocation = InitializeAndGetArcHCIExtendedLoc $using:azUser $using:azPassword $using:resourceGroup
+                    if (-not $extendedLocation) {
+                        LogOutput -ForegroundColor Red "Error generating Extended Location value"
+                        return "Error occurred while getting extended location"
+                    }
 
+                    $location = (Get-AzureStackHCI | select Region).Region
+
+                    $spId = $null
+                    $spResult = az stack-hci-vm storagepath list --resource-group $using:resourceGroup --query "[?name=='$($using:storagePath)' && properties.provisioningState=='Succeeded'].id"  --output tsv
+                    if (-not $spResult) {
+                        LogOutput "Creating storage path $storagePath..."
+                        $spResult = az stack-hci-vm storagepath create --name $using:storagePath --resource-group $using:resourceGroup --custom-location $extendedLocation --path $using:storagePathCsv --location $location | ConvertFrom-Json
+                    }
+                    elseif (az stack-hci-vm storagepath list --resource-group $using:resourceGroup --query "[?name=='$($using:storagePath)' && properties.provisioningState=='Failed'].id"  --output tsv) {
+                        LogOutput "$using:storagePath exists with provision status Failed. Deleting existing storage path and recreating..."
+                        az stack-hci-vm storagepath delete --name $using:storagePath --resource-group $using:resourceGroup --yes
+                        $spResult = az stack-hci-vm storagepath create --name $using:storagePath --resource-group $using:resourceGroup --custom-location $extendedLocation --path $using:storagePathCsv --location $location | ConvertFrom-Json
+                    }
+
+                    if (-not $spResult) {
+                        throw "Failed to create storage path $using:storagePath"
+                    }
+                    if($spResult.Id) {
+                        $spId = $spResult.Id
+                    }
+                    else {
+                        $spId = $spResult
+                    }
+                    LogOutput "Initialized storage path: $using:storagePath, creating image with $vhdPath..."
+
+                    $imgResult = az stack-hci-vm image list --resource-group $using:resourceGroup  --query "[?name=='$($using:image)' && properties.provisioningState=='Succeeded'].id" --output tsv
+                    if (-not $imgResult) {
+                        LogOutput "Creating image $using:image..."
+                        $imgResult = az stack-hci-vm image create --name $using:image --resource-group $using:resourceGroup --location $location --custom-location $extendedLocation --os-type Windows --storage-path-id $spId --image-path $vhdPath | ConvertFrom-Json
+                    }
+                    elseif (az stack-hci-vm image list --resource-group $using:resourceGroup  --query "[?name=='$($using:image)' && properties.provisioningState=='Failed'].id" --output tsv) {
+                        LogOutput "$using:image exists with provision status Failed. Deleting existing image and recreating..."
+                        az stack-hci-vm image delete --name $using:image --resource-group $using:resourceGroup --yes
+                        $imgResult = az stack-hci-vm image create --name $using:image --resource-group $using:resourceGroup --location $location --custom-location $extendedLocation --os-type Windows --storage-path-id $spId --image-path $vhdPath | ConvertFrom-Json
+                    }
+
+                    if (-not $imgResult) {
+                        throw "Failed to create image $using:image"
+                    }
+
+                    LogOutput "Initialized Gallery image: $using:image"
+                    LogOutput -ForegroundColor Green "Finished initialization of resources using Azure CLI"
+                    break
+                }
+                catch {
+                    $retryCount++
+                    if ($retryCount -eq 3) {
+                        return "Error occurred while creating Azure resources for all retry counts"
+                    }
+                }
+            }
+        }
+        if($result -ne $null -and $result.Contains("Error")){
+            return $result
+        }
+    }
+
+    #### STOPAFTER
+    if (Stop-After "CreateVMSwitch" $stopafter) {
+        return
+    }
+
+    Invoke-CommonCommand $nodes -InitBlock $CommonFunc -ArgumentList @(,$csvs) -ScriptBlock {
         param($csvs)
 
-        function ApplySpecialization( $path, $vmspec )
-        {
-            # all steps here can fail immediately without cleanup
+           foreach ($csv in $csvs) {
 
-            # error accumulator
-            $ok = $true
+           if ($($using:groups).Length -eq 0) {
+               $groups = @( 'base' )
+           } else {
+               $groups = $using:groups
+           }
 
-            # create run directory
+           # identify the CSvs for which this node should create its VMs
+           # the trailing characters (if any) are the group prefix
+           if ($csv.VDName -notmatch "^$env:COMPUTERNAME(?:-.+){0,1}") {
+               continue
+           }
 
-            Remove-Item -Recurse -Force z:\run -ErrorAction SilentlyContinue
-            mkdir z:\run
-            $ok = $ok -band $?
-            if (-not $ok) {
-                Write-Error "failed run directory creation for $vhdpath"
-                return $ok
-            }
+           foreach ($group in $groups) {
 
-            # autologon
-            $null = reg load 'HKLM\tmp' z:\windows\system32\config\software
-            $ok = $ok -band $?
-            $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v DefaultUserName /t REG_SZ /d $using:admin
-            $ok = $ok -band $?
-            $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v DefaultPassword /t REG_SZ /d $using:adminpass
-            $ok = $ok -band $?
-            $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v AutoAdminLogon /t REG_DWORD /d 1
-            $ok = $ok -band $?
-            $null = reg add 'HKLM\tmp\Microsoft\Windows NT\CurrentVersion\WinLogon' /f /v Shell /t REG_SZ /d 'powershell.exe -noexit -command C:\users\administrator\launch.ps1'
-            $ok = $ok -band $?
+               if ($csv.VDName -match "^$env:COMPUTERNAME-([^-]+)$") {
+                   $g = $group+$matches[1]
+               } else {
+                   $g = $group
+               }
 
-            $null = reg unload 'HKLM\tmp'
-            $ok = $ok -band $?
-            if (-not $ok) {
-                Write-Error "failed autologon injection for $vhdpath"
-                return $ok
-            }
+               foreach ($vm in 1..$using:vms) {
 
-            # scripts
+                   $stop = $false
 
-            Copy-Item -Force C:\ClusterStorage\collect\control\control.ps1 z:\run\control.ps1
-            $ok = $ok -band $?
-            if (-not $ok) {
-                Write-Error "failed injection of specd master.ps1 for $vhdpath"
-                return $ok
-            }
+                   $newvm = $false
+                   if($using:createArcVMs) {
+                      $name = ("vm-$g-$env:COMPUTERNAME-$using:salt-{0:000}" -f $vm)
+                   }
+                   else {
+                      $name = ("vm-$g-$env:COMPUTERNAME-{0:000}" -f $vm)
+                   }
 
-            #
-            # Wrapper for the controller script to auto-restart on failure/update.
-            # This is the autologin script itself.
-            #
-            function Set-FleetLauncherScript
-            {
-                $script = 'C:\run\control.ps1'
+                   $placePath = $csv.FriendlyVolumeName
+                   $vmPath = Join-Path $placePath $name
+                   $vhdPath = Join-Path $vmPath "$name.vhdx"
 
-                while ($true) {
-                    Write-Host -fore Green Launching $script `@ $(Get-Date)
-                    try { & $script -connectuser __CONNECTUSER__ -connectpass '__CONNECTPASS__' } catch {}
-                    Start-Sleep -Seconds 1
-                }
-            }
-
-            Remove-Item -Force z:\users\administrator\launch.ps1 -ErrorAction SilentlyContinue
-            (Get-Command Set-FleetLauncherScript).ScriptBlock |% {
-                $_ -replace '__CONNECTUSER__',$using:connectuser -replace '__CONNECTPASS__',$using:connectpass
-            } > z:\users\administrator\launch.ps1
-            $ok = $ok -band $?
-            if (-not $ok) {
-                Write-Error "failed injection of launch.ps1 for $vhdpath"
-                return $ok
-            }
-
-            Write-Output $vmspec > z:\vmspec.txt
-            $ok = $ok -band $?
-            if (-not $ok) {
-                Write-Error "failed injection of vmspec for $vhdpath"
-                return $ok
-            }
-
-            # load files
-            $f = 'z:\run\testfile1.dat'
-            if (-not (Get-Item $f -ErrorAction SilentlyContinue)) {
-                fsutil file createnew $f (10GB)
-                $ok = $ok -band $?
-                fsutil file setvaliddata $f (10GB)
-                $ok = $ok -band $?
-            }
-            if (-not $ok) {
-                Write-Error "failed creation of initial load file for $vhdpath"
-                return $ok
-            }
-
-            return $ok
-        }
-
-        function SpecializeVhd( $vhdpath )
-        {
-            $vhd = (Get-Item $vhdpath)
-            $vmspec = $vhd.BaseName
-
-            # mount vhd and its largest partition
-            $o = Mount-VHD $vhd -NoDriveLetter -Passthru
-            if ($null -eq $o) {
-                Write-Error "failed mount for $vhdpath"
-                return $false
-            }
-            $p = Get-Disk -number $o.DiskNumber | Get-Partition | Sort-Object -Property size -Descending | Select-Object -first 1
-            $p | Add-PartitionAccessPath -AccessPath Z:
-
-            $ok = ApplySpecialization Z: $vmspec
-
-            Remove-PartitionAccessPath -AccessPath Z: -InputObject $p
-            Dismount-VHD -DiskNumber $o.DiskNumber
-
-            return $ok
-        }
-
-        foreach ($csv in $csvs) {
-
-            if ($($using:groups).Length -eq 0) {
-                $groups = @( 'base' )
-            } else {
-                $groups = $using:groups
-            }
-
-            # identify the CSvs for which this node should create its VMs
-            # the trailing characters (if any) are the group prefix
-            if ($csv.VDName -notmatch "^$env:COMPUTERNAME(?:-.+){0,1}") {
-                continue
-            }
-
-            foreach ($group in $groups) {
-
-                if ($csv.VDName -match "^$env:COMPUTERNAME-([^-]+)$") {
-                    $g = $group+$matches[1]
-                } else {
-                    $g = $group
-                }
-
-                foreach ($vm in 1..$using:vms) {
-
-                    $stop = $false
-
-                    $newvm = $false
-                    $name = ("vm-$g-$env:COMPUTERNAME-{0:000}" -f $vm)
-
-                    $placePath = $csv.FriendlyVolumeName
-                    $vmPath = Join-Path $placePath $name
-                    $vhdPath = Join-Path $vmPath "$name.vhdx"
-
-                    # if the vm cluster group exists, we are already deployed
-                    if (-not (Get-ClusterGroup -Name $name -ErrorAction SilentlyContinue)) {
+                   # if the vm cluster group exists, we are already deployed
+                   if (-not (Get-ClusterGroup -Name $name -ErrorAction SilentlyContinue)) {
 
                         if (-not $stop) {
                             $stop = Stop-After "AssertComplete"
                         }
 
-                        if ($stop) {
+                       if ($stop) {
 
-                            LogOutput -ForegroundColor Red "vm $name not deployed"
+                           LogOutput -ForegroundColor Red "vm $name not deployed"
 
-                        } else {
+                       } else {
 
-                            LogOutput "CREATE vm $name @ path $vmPath"
+                           LogOutput "CREATE vm $name @ path $vmPath"
 
-                            # always specialize new vms
-                            $newvm = $true
+                           # always specialize new vms
+                           $newvm = $true
 
-                            # We're on the canonical node to create the vm; if the vm exists, tear it down and refresh
-                            $o = Get-VM -Name $name -ErrorAction SilentlyContinue
+                           # We're on the canonical node to create the vm; if the vm exists, tear it down and refresh
+                           $o = Get-VM -Name $name -ErrorAction SilentlyContinue
 
-                            if ($null -ne $o) {
+                           if ($null -ne $o) {
 
-                                # interrupted between vm creation and role creation; redo it
-                                LogOutput "REMOVE vm $name for re-creation"
+                               # interrupted between vm creation and role creation; redo it
+                               LogOutput "REMOVE vm $name for re-creation"
 
-                                if ($o.State -ne 'Off') {
-                                    Stop-VM -Name $name -TurnOff -Force -Confirm:$false
-                                }
-                                Remove-VM -Name $name -Force -Confirm:$false
-                            }
+                               if ($o.State -ne 'Off') {
+                                   Stop-VM -Name $name -TurnOff -Force -Confirm:$false
+                               }    
+                               if($using:createArcVMs){
+                                   az stack-hci-vm delete --name $name --resource-group $using:resourceGroup --yes
+                               }
+                               else {                        
+                                   Remove-VM -Name $name -Force -Confirm:$false
+                               }
+                           }
+                           # we do not need to copy vhd for Arc vms. It is done by the product code itself
+                           if($using:createArcVMs -eq $false){
+                               # scrub and re-create the vm metadata path and vhd
+                               if (Test-Path $vmPath)
+                               {
+                                   Remove-Item -Recurse $vmPath
+                               }
 
-                            # scrub and re-create the vm metadata path and vhd
-                            if (Test-Path $vmPath)
-                            {
-                                Remove-Item -Recurse $vmPath
-                            }
+                               $null = New-Item -ItemType Directory $vmPath
+                               Copy-Item $using:BaseVHD $vhdPath
 
-                            $null = New-Item -ItemType Directory $vmPath
-                            Copy-Item $using:BaseVHD $vhdPath
+                               #### STOPAFTER
+                               if (-not $stop) {
+                                   $stop = Stop-After "CopyVHD" $using:stopafter
+                               }
 
-                            #### STOPAFTER
-                            if (-not $stop) {
-                                $stop = Stop-After "CopyVHD" $using:stopafter
-                            }
+                               if (-not $stop) {
 
-                            if (-not $stop) {
+                                   # Create A1 VM. use set-vmfleet to alter fleet sizing post-creation.
+                                   # Do not monitor the internal switch connection; this allows live migration
+                                   # despite the internal switch.
+                                   $o = New-VM -VHDPath $vhdPath -Generation 2 -SwitchName $using:vmSwitchName -Path $placePath -Name $name
+                                   if ($null -ne $o)
+                                   {
+                                       $o | Set-VM -ProcessorCount 1 -MemoryStartupBytes 1.75GB -StaticMemory
+                                       $o | Get-VMNetworkAdapter | Set-VMNetworkAdapter -NotMonitoredInCluster $true
+                                   }
+                               }
+                           }
+                           else {
+                                   $retrycount = 0
+                                   while($retrycount -lt 3){
+                                       try{
+                                            $vmResult = $null
+                                            $extendedLocation = InitializeAndGetArcHCIExtendedLoc $using:azUser $using:azPassword $using:resourceGroup
+                                            $location = (Get-AzureStackHCI | select Region).Region
+                                            LogOutput "Creating Arc HCI VM - $name ..."
+                                            $vmResult = az stack-hci-vm create --name $name --resource-group $using:resourceGroup --admin-username $using:admin --admin-password $using:adminpass --computer-name $using:admin --location $location --enable-agent False --enable-vm-config-agent false --os-type "Windows" --custom-location $extendedLocation --image $using:image --storage-path-id  $using:storagePath --hardware-profile memory-mb="2048" processors="1" vm-size="Custom"
+                                            LogOutput "Result returned for $name - $vmResult"
+                                            if($vmResult -eq $null){
+                                                $msg = "Error creating Virtual machine $name at retry count $retryCount"
+                                                LogOutput -ForegroundColor Yellow $msg
+                                                throw $msg
+                                            }
+                                            break
+                                       }
+                                       catch {
+                                          $retrycount++
+                                          if($retrycount -eq 3){
+                                               LogOutput -ForegroundColor Yellow "Error occurred while creating $name for all retry counts"
+                                               $stop = $true
+                                          }
+                                       }
+                                   }
+                                   if (-not $stop) {
+                                       # validating creation of Arc VMs using powershell commands
+                                       # hyperv Arc VM names
+                                       $vmname = "Virtual Machine " + $name
+                                       $Stoploop = $false
+                                       $Retrycount = 0
+                                       do {
+                                           try {
+                                               LogOutput "Executing Get-ClusterResource -Name $vmname"
+                                               $o = Get-ClusterResource -Name $vmname
+                                               if ($o -eq $null) {
+                                                   throw "Null returned by Get-ClusterResource due to some error"
+                                               }
+                                               else {
+                                                  LogOutput "Creation of vm completed at hyperv level"
+                                                   $Stoploop = $true
+                                               }
+                                           }
+                                           catch {
+                                               if ($Retrycount -gt 10) {
+                                                   LogOutput "Could not get VM $vmname after 10 retries using Get-ClusterResource"
+                                                   $Stoploop = $true
+                                               }
+                                               else {
+                                                   Write-Host "Could not get VM $vmname at $RetryCount retry count. Retrying in 6 minutes..."
+                                                   LogOutput "Starting with some sleep time"
+                                                   Start-Sleep -Seconds 360
+                                                   $Retrycount += 1
+                                               }
+                                           }
+                                       }
+                                       While ($Stoploop -eq $false)      
+                                   }
+                           }
+                           #### STOPAFTER
+                           if (-not $stop) {
+                               $stop = Stop-After "CreateVM" $using:stopafter
+                           }
 
-                                # Create A1 VM. use set-vmfleet to alter fleet sizing post-creation.
-                                # Do not monitor the internal switch connection; this allows live migration
-                                # despite the internal switch.
-                                $o = New-VM -VHDPath $vhdPath -Generation 2 -SwitchName $using:vmSwitchName -Path $placePath -Name $name
-                                if ($null -ne $o)
-                                {
-                                    $o | Set-VM -ProcessorCount 1 -MemoryStartupBytes 1.75GB -StaticMemory
-                                    $o | Get-VMNetworkAdapter | Set-VMNetworkAdapter -NotMonitoredInCluster $true
-                                }
-                            }
+                           if (-not $stop -and $using:createArcVMs -ne $true) {
+                               # Create clustered vm role (don't emit) and assign default owner node.
+                               # Swallow the (expected) warning that will be referring to the internal
+                               # vmswitch as being a local-only resource. Since we replicate the vswitch
+                               # with the same IP on each cluster node, it does work.
+                               #
+                               # If an error occurs, it will emit per normal.
+                               $null = $o | Add-ClusterVirtualMachineRole -WarningAction SilentlyContinue
+                               Set-ClusterOwnerNode -Group $o.VMName -Owners $env:COMPUTERNAME
+                           }
+                       }
 
-                            #### STOPAFTER
-                            if (-not $stop) {
-                                $stop = Stop-After "CreateVM" $using:stopafter
-                            }
+                   } else {
+                       LogOutput -ForegroundColor Green "vm $name already deployed"
+                   }
 
-                            if (-not $stop) {
+                   #### STOPAFTER
+                   if (-not $stop) {
+                       $stop = Stop-After "CreateVMGroup" $using:stopafter
+                   }
 
-                                # Create clustered vm role (don't emit) and assign default owner node.
-                                # Swallow the (expected) warning that will be referring to the internal
-                                # vmswitch as being a local-only resource. Since we replicate the vswitch
-                                # with the same IP on each cluster node, it does work.
-                                #
-                                # If an error occurs, it will emit per normal.
-                                $null = $o | Add-ClusterVirtualMachineRole -WarningAction SilentlyContinue
-                                Set-ClusterOwnerNode -Group $o.VMName -Owners $env:COMPUTERNAME
-                            }
-                        }
+                   if ((-not $stop -or ($using:specialize -eq 'Force')) -and -not $using:createArcVMs) {
+                       # specialize as needed
+                       # auto only specializes new vms; force always; none skips it
+                       if (($using:specialize -eq 'Auto' -and $newvm) -or ($using:specialize -eq 'Force')) {
+                           LogOutput "SPECIALIZE vm $name"
+                           if (-not (SpecializeVhd $vhdPath $using:admin $using:adminpass $using:connectuser $using:connectpass)) {
+                               LogOutput -ForegroundColor red "Failed specialize of vm $name @ $vhdPath, halting."
+                           }
+                       } else {
+                           LogOutput -ForegroundColor green skip specialize $vhdPath
+                       }
+                   }
+               }
+           }
+       }
+    }
 
-                    } else {
-                        LogOutput -ForegroundColor Green "vm $name already deployed"
-                    }
-
-                    #### STOPAFTER
-                    if (-not $stop) {
-                        $stop = Stop-After "CreateVMGroup" $using:stopafter
-                    }
-
-                    if (-not $stop -or ($using:specialize -eq 'Force')) {
-                        # specialize as needed
-                        # auto only specializes new vms; force always; none skips it
-                        if (($using:specialize -eq 'Auto' -and $newvm) -or ($using:specialize -eq 'Force')) {
-                            LogOutput "SPECIALIZE vm $name"
-                            if (-not (SpecializeVhd $vhdPath)) {
-                                LogOutput -ForegroundColor red "Failed specialize of vm $name @ $vhdPath, halting."
-                            }
-                        } else {
-                            LogOutput -ForegroundColor green skip specialize $vhdPath
-                        }
-                    }
-                }
-            }
+    if($createArcVMs){
+        Stop-Fleet
+        LogOutput "Updating network adapter for Fleet to add internal switch"
+        $clusterName = (Get-Cluster).Name
+        $nodes = @(Get-ClusterNode -Cluster $clusterName | ? State -eq Up)
+        $regPattern = "^vm-.{1,}-" + $salt + "-\d{3}$"
+        foreach ($o in Get-VM -CimSession $nodes.Name | ? Name -match $regPattern) {
+            $o | Add-VMNetworkAdapter -SwitchName $vmSwitchName
+            $o | Get-VMNetworkAdapter | Connect-VMNetworkAdapter -SwitchName $vmSwitchName        
+            $o | Get-VMNetworkAdapter | Set-VMNetworkAdapter -NotMonitoredInCluster $true
+            Set-ClusterOwnerNode -Group $o.VMName -Owners $env:COMPUTERNAME
+            LogOutput "Network Adapter attached to VM"
         }
+        Stop-Fleet
+        Initialize-ArcVMs $admin $adminpass $connectuser $connectpass $salt
+    }
+}
+
+# Initialize Arc VMs
+function Initialize-ArcVMs ($admin ,$adminpass, $connectuser, $connectpass, $salt){
+    $clusterName = (Get-Cluster).Name
+    $nodes = @(Get-ClusterNode -Cluster $clusterName | ? State -eq Up)
+    $regPattern = "^vm-.{1,}-" + $salt + "-\d{3}$"
+    foreach ($vm in Get-VM -CimSession $nodes.Name | ? Name -match $regPattern) {
+        $vmname = "Virtual Machine " + $vm.Name
+        $name = $vm.Name
+        $vhdPath = $vm | Select-Object -ExpandProperty HardDrives | Where-Object Path -like "*OSDisk*.vhdx" | Select Path
+        if($vhdPath -eq $null){
+            LogOutput -ForegroundColor red "Could not find vhd path for $vmname."
+        }
+        $path = $vhdPath.Path
+        if (-not (SpecializeVhd $path $admin $adminpass $connectuser $connectpass $name)) {
+            LogOutput -ForegroundColor red "Failed specialize of vm $name @ $path, halting."
+        }
+        else { LogOutput -ForegroundColor green "Successfully Specialized $vmname" }
     }
 }
 
@@ -2536,6 +2789,26 @@ function Remove-Fleet
     $clusterParam = @{}
     CopyKeyIf $PSBoundParameters $clusterParam 'Cluster'
 
+    # check if Arc enabled VMs should be created   
+    $arcConfig = Get-ArcConfig -Cluster $Cluster
+    $arcEnvEnabled = $arcConfig -and $arcConfig.Enabled
+    $resourceGroup, $azUser, $azPassword, $storagePath, $img, $salt = $null
+    if($arcEnvEnabled){
+       $resourceGroup, 
+       $azUser, 
+       $azPassword, 
+       $storagePath, 
+       $img, 
+       $salt = 
+       $arcConfig.ResourceGroup, 
+       $arcConfig.AzureRegistrationUser,
+       $arcConfig.AzureRegistrationPassword, 
+       $arcConfig.StoragePathName, 
+       $arcConfig.ImageName, 
+       $arcConfig.Salt
+       LogOutput "Is environment HCI Arc-enabled? $arcEnvEnabled"
+    }
+
     if ($vms)
     {
         LogOutput -IsVb "Removing VM Fleet content for: $vms"
@@ -2551,6 +2824,10 @@ function Remove-Fleet
         if ($vms)
         {
             $_.Name -in $vms
+        }
+        elseif($arcEnvEnabled)
+        {
+            $_.Name -match "^vm-.{1,}-" + $salt + "-\d{3}$"
         }
         else
         {
@@ -2574,6 +2851,10 @@ function Remove-Fleet
             {
                 $_.Name -in $using:vms
             }
+            elseif($using:arcEnvEnabled) 
+            {
+               $_.Name -match "^vm-.{1,}-" + $using:salt + "-\d{3}$"
+            }
             else
             {
                 $_.Name -like 'vm-*'
@@ -2581,10 +2862,18 @@ function Remove-Fleet
         } |% {
 
             LogOutput -IsVb "Removing VM for $($_.Name) @ $($env:COMPUTERNAME)"
-            $_ | Remove-VM -Confirm:$false -Force
+            if($using:arcEnvEnabled) {
+                InitializeAndGetArcHCIExtendedLoc $using:azUser $using:azPassword $using:resourceGroup
+                $vmName = $_.Name
+                az stack-hci-vm delete --name $vmName --resource-group $using:resourceGroup --yes
+                LogOutput "Removed $vmName"
+            }
+            else {
+                $_ | Remove-VM -Confirm:$false -Force
+                # remove hosting directory and any flag files associated with this VM
+                Remove-Item $_.Path -Recurse -Force
+            }
 
-            # remove hosting directory and any flag files associated with this VM
-            Remove-Item $_.Path -Recurse -Force
             $f = Join-Path $using:flagPath "*-$($_.Name)"
             if (Test-Path $f)
             {
@@ -2602,6 +2891,25 @@ function Remove-Fleet
                 $switch | Remove-VMSwitch -Confirm:$False -Force
             }
         }
+    }
+    
+    if($arcEnvEnabled){
+       $nodes = Get-ClusterNode @clusterParam
+       Invoke-CommonCommand $nodes[0] -InitBlock $CommonFunc -ScriptBlock {
+           InitializeAndGetArcHCIExtendedLoc $using:azUser $using:azPassword $using:resourceGroup
+           $imgList = az stack-hci-vm image list --resource-group $using:resourceGroup | ConvertFrom-Json
+           $existingImage = $imgList | Where-Object name -eq $using:img           
+           if($existingImage){
+               LogOutput "Deleting image - $($using:img)"
+               az stack-hci-vm image delete --name $using:img --resource-group $using:resourceGroup --yes
+           }
+           $spList = az stack-hci-vm storagepath list --resource-group $using:resourceGroup | ConvertFrom-Json
+           $existingSP = $spList | Where-Object name -eq $using:storagePath
+           if($existingSP){
+               LogOutput "Deleting Storage Path - $($using:storagePath)"
+               az stack-hci-vm storagepath delete --name $using:storagePath --resource-group $using:resourceGroup --yes
+           }
+       }
     }
 
     # Fallback to clear remnant content due to earlier errors/etc.
@@ -2625,9 +2933,10 @@ function Remove-Fleet
         } |% {
 
             LogOutput -IsVb "Removing CSV content for $($_.BaseName) @ $($_.FullName)"
-
-            # remove hosting directory and any flag files associated with this VM
-            Remove-Item $_.FullName -Recurse -Force
+            if(-not $arcEnvEnabled){
+                # remove hosting directory and any flag files associated with this VM
+                Remove-Item $_.FullName -Recurse -Force
+            }
             $f = Join-Path $flagPath "*-$($_.Name)"
             if (Test-Path $f)
             {
@@ -2973,7 +3282,13 @@ function Get-FleetVM
     # Parameter set specifying cluster only
     $clusterParam = @{}
     CopyKeyIf $PSBoundParameters $clusterParam 'Cluster'
-
+    # check if VMs are created in Arc environment
+    $arcConfig = Get-ArcConfig -Cluster $Cluster
+    $arcEnvEnabled = $arcConfig -and $arcConfig.Enabled
+    $salt = $null
+    if($arcEnvEnabled) {
+       $salt = $arcConfig.Salt
+    }
     #
     # Start timeout; only takes effect after first control response check.
     #
@@ -2983,8 +3298,16 @@ function Get-FleetVM
     $clusterView = @{}
     $vmView = @{}
     Get-ClusterGroup @clusterParam |? GroupType -eq VirtualMachine           |? Name -like "vm-$Group-*" |% { $clusterView[$_.Name] = $_ }
-    Get-VM -CimSession @(Get-ClusterNode @clusterParam |? State -eq Up).Name |? Name -like "vm-$Group-*" |% { $vmView[$_.Name] = $_ }
-
+    Get-VM -CimSession @(Get-ClusterNode @clusterParam |? State -eq Up).Name |? {
+        if($arcEnvEnabled) 
+        {
+            $_.Name -like "^vm-$Group-.{1,}-" + $salt + "-\d{3}$"
+        }
+        else
+        {
+            $_.Name -like "vm-$Group-*" 
+        }
+    } |% { $vmView[$_.Name] = $_ }
     # Union into a composite vm health/state object
     # Pass 1 through cluster groups. Pass 2 through VMs to detect those
     # not attached as cluster groups (not expected).
@@ -3429,7 +3752,7 @@ function Move-Fleet
             $arr = [collections.arraylist]@()
             foreach ($vm in $vms | Sort-Object -Property Name)
             {
-                if ($vm.Name -match "vm-.*-$($node.Name)-\d+$")
+                if ($vm.Name -match "vm-.*-$($node.Name).*-\d+$")
                 {
                     $null = $arr.Add($vm)
                 }
@@ -3864,10 +4187,20 @@ function Set-Fleet
     )
 
     $nodes = @(Get-ClusterNode -Cluster $Cluster |? State -eq Up)
-
+    # check if VMs are created in Arc environment
+    $arcConfig = Get-ArcConfig -Cluster $Cluster
+    $arcEnvEnabled = $arcConfig -and $arcConfig.Enabled
+    $resourceGroup, $salt = $null
+    if($arcEnvEnabled) {
+       $resourceGroup = $arcConfig.ResourceGroup
+       $salt = $arcConfig.Salt
+    }
     # Fill parameters
     $p = @{}
-
+    if($arcEnvEnabled){
+        $p['ArcEnvEnabled'] = $arcEnvEnabled
+        $p['ResourceGroup'] = $resourceGroup
+    }
     switch ($PSCmdlet.ParameterSetName) {
 
         'FullSpecDynamic'
@@ -3925,7 +4258,20 @@ function Set-Fleet
                 }
                 else
                 {
-                    $vm | Set-VM @p
+                    if($p['ArcEnvEnabled']){
+                        $name = $vm.Name
+                        $cpuCount = $p['ProcessorCount']
+                        $memorymb = $p['MemoryStartupBytes']/1048576
+                        $rg = $p['ResourceGroup']
+                        # for now, this script only supports static memory for Arc vms
+                        az stack-hci-vm update --name $name --v-cpus-available $cpuCount --memory-mb $memorymb --resource-group $rg
+                        # currently, vms go back to running state instead of original state before peforming an update
+                        az stack-hci-vm stop --name $name --resource-group $rg
+                    }
+                    else {
+                        $vm | Set-VM @p
+                    }
+
                     continue
                 }
             }
@@ -3939,7 +4285,15 @@ function Set-Fleet
         # Update-ClusterVirtualMachineConfiguration is invoked to update the clustered role when disks are modifieed.
         #
 
-        $vms = @(Get-VM -CimSession $nodes.Name |? Name -like 'vm-*')
+        $vms = @(Get-VM -CimSession $nodes.Name |? {
+            if($arcEnvEnabled) {
+                $_.Name -match "^vm-.{1,}-" + $salt + "-\d{3}$"
+            }
+            else {
+                $_.Name -like 'vm-*'
+            }
+        }
+        )
         for ($i = 0; $i -lt $vms.Count; ++$i)
         {
             $vm = $vms[$i]
@@ -3987,7 +4341,14 @@ function Set-Fleet
 
                 function Create
                 {
-                    $path = Join-Path $vm.Path "data.vhdx"
+                    if($arcEnvEnabled){
+                        $vmName = $vm.Name
+                        $dataDiskName = "data-$vmName.vhdx"
+                        $path = Join-Path $vm.Path $dataDiskName
+                    }
+                    else {
+                        $path = Join-Path $vm.Path "data.vhdx"
+                    }
 
                     if ($null -eq $path)
                     {
@@ -5077,6 +5438,45 @@ function Clear-FleetRunState
     Write-Output 0 > $goPath
 }
 
+function Create-TemplateRunScript
+{
+    [CmdletBinding()]
+    param(
+        [string]
+        $AddSpec = "",
+
+        [string]
+        $controlPath,
+
+        [string]
+        $RunFile = "sweep.ps1",
+
+        [string]
+        $RunProfileFile = "sweep.xml"
+    )
+
+     # Pause for SMB dir/info cache to expire and surface go flag.
+     # Runner will wait for new content - note unique guid.
+     Start-Sleep $smbInfoCacheLifetime
+
+    $vmprof = "L:\control\$RunProfileFile"
+    $guid = [System.Guid]::NewGuid().Guid
+
+    $f = Join-Path $controlPath $RunFile
+    $(Get-Command Set-RunProfileTemplateScript).ScriptBlock |% {
+
+        # apply subsitutions to produce a new run file
+        $line = $_
+        $line = $line -replace '__AddSpec__',$AddSpec
+        $line = $line -replace '__Profile__',$vmprof
+        $line = $line -replace '__Unique__',$guid
+        $line
+
+    } | Out-File "$($f).tmp" -Encoding ascii -Width ([int32]::MaxValue)
+    if (Test-Path $f) { Remove-Item $f -Force }
+    Rename-Item "$($f).tmp" $RunFile
+}
+
 function Start-FleetRun
 {
     [CmdletBinding()]
@@ -5239,26 +5639,7 @@ function Start-FleetRun
     # Create templated run script to inject this profile?
     if ($psCmdlet.ParameterSetName -ne "ByPrePlaced")
     {
-         # Pause for SMB dir/info cache to expire and surface go flag.
-         # Runner will wait for new content - note unique guid.
-         Start-Sleep $smbInfoCacheLifetime
-
-        $vmprof = "L:\control\$RunProfileFile"
-        $guid = [System.Guid]::NewGuid().Guid
-
-        $f = Join-Path $controlPath $RunFile
-        $(Get-Command Set-RunProfileTemplateScript).ScriptBlock |% {
-
-            # apply subsitutions to produce a new run file
-            $line = $_
-            $line = $line -replace '__AddSpec__',$AddSpec
-            $line = $line -replace '__Profile__',$vmprof
-            $line = $line -replace '__Unique__',$guid
-            $line
-
-        } | Out-File "$($f).tmp" -Encoding ascii -Width ([int32]::MaxValue)
-        if (Test-Path $f) { Remove-Item $f -Force }
-        Rename-Item "$($f).tmp" $RunFile
+         Create-TemplateRunScript $AddSpec $controlPath $RunFile $RunProfileFile
     }
 
     # capture time zero
@@ -7190,6 +7571,96 @@ function Test-FleetResultRun
     return ($n -ne 0)
 }
 
+# Generates and sets up the run profile XML file for a given workload profile
+# Can be used for free runs
+function Set-FleetRunProfileScript
+{
+    param(
+        [string]
+        $Cluster = ".",
+
+        [Parameter(Mandatory=$true)] 
+        [xml]
+        $ProfileXml,
+
+        [switch]
+        $CpuSweep,
+
+        [switch]
+        $UseStorageQos,
+
+        [uint32]
+        $SearchWarmup = 0,
+
+        [string]
+        $RunFile = "sweep.ps1",
+
+        [string]
+        $RunProfileFile = "sweep.xml"
+        )
+
+        $clusterParam = @{}
+        CopyKeyIf $PSBoundParameters $clusterParam 'Cluster'
+
+        if ($CpuSweep -and -not (IsProfileSingleTimespan -ProfileXml $ProfileXml))
+        {
+            Write-Error "Profile for a CpuSweep can only contain a single timespan"
+            return
+        }
+
+        $QoS = 0 
+
+        if (IsProfileThroughputLimited -ProfileXml $ProfileXml)
+        {
+            $addspec = "baseline"
+            if ($CpuSweep)
+            {
+                if(IsProfileSingleTarget -ProfileXml $ProfileXml -and $SearchWarmup)
+                {              
+                $ProfileXml = $ProfileXml | Set-FleetProfile -Warmup $SearchWarmup      
+                }
+            }
+        }
+        else
+        {
+            $addspec = "qos$qos"
+            if ($CpuSweep)
+            {
+                if ($UseStorageQos)
+                {
+                    Set-StorageQosPolicy -Name SweepQoS -MaximumIops $QoS @cimParam
+                }
+                else
+                {
+                    $ProfileXml = $ProfileXml | Set-FleetProfile -Throughput $QoS -ThroughputUnit IOPS
+                }
+            }
+        }
+
+        $accessNode = Get-AccessNode @clusterParam
+        $cimParam = @{ CimSession = $accessNode }
+
+        if ($VerbosePreference)
+        {
+            $ProfileXml | Convert-FleetXmlToString |% { LogOutput -IsVb $_ }
+        }
+
+        $Duration = GetProfileDuration -ProfileXml $ProfileXml -Total
+
+        if ($null -eq $Duration -or $Duration -eq 0)
+        {
+            Write-Error "Run duration could not be determined, cannot continue"
+            return
+        }
+
+        $controlPath = Get-FleetPath -PathType Control @clusterParam
+        $runProfileFilePath = Join-Path $controlPath $RunProfileFile
+        Remove-Item $runProfileFilePath -Force -ErrorAction SilentlyContinue
+        $ProfileXml | Convert-FleetXmlToString | Out-File $runProfileFilePath -Encoding ascii -Width ([int32]::MaxValue) -Force
+
+        Create-TemplateRunScript $addspec $controlPath $RunFile $RunProfileFile
+}
+
 function Start-FleetResultRun
 {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -8665,4 +9136,152 @@ function SetCacheBehavior
             Remove-PSSession -Session $s
         }
     }
+}
+
+function Get-Salt {
+    $salt = ([char]'a'..[char]'z' + [char]'A'..[char]'Z' + [char]'0'..[char]'9' | Get-Random -Count 4 |% { [char]$_ }) -join ''
+    Write-Host "Generated Salt: $salt"
+    return $salt;
+}
+
+function Get-ArcConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Cluster = "."
+    )
+
+    $controlPath = Get-FleetPath -PathType Control $Cluster
+    $f = Join-Path $controlPath "arc.json"
+    if (-not (Test-Path $f)) {
+        Write-Host "arc.json does not exist. Current Arc mode: Disabled."
+        return $null
+    }
+
+    $arcConfig = Get-Content -Path $f -Raw | ConvertFrom-Json
+    return $arcConfig
+}
+
+function Set-ArcConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$ResourceGroup,
+
+        [Parameter()]       
+        [string]$AzureRegistrationUser,
+
+        [Parameter()]
+        [string]$AzureRegistrationPassword,
+        
+        [Parameter()]
+        [string]$StoragePathCsv,
+
+        [Parameter()]
+        [string]$StoragePathName = "arcVmFleetStoragePath",
+
+        [Parameter()]
+        [string]$ImageName = "arcVmFleetImage",
+        
+        [Parameter()]
+        [bool]
+        $Enabled = $false,
+
+        [Parameter()]
+        [switch]
+        $ResetSalt,
+
+        [Parameter()]
+        [string]
+        $Cluster = "."
+    )
+
+    if($PSBoundParameters.Count -eq 0){
+        Write-Host "Set atleast one property."
+        return;
+    }
+    if($PSBoundParameters.ContainsKey("ResetSalt")) {
+        $PSBoundParameters.Remove('ResetSalt') | Out-Null
+    }
+    $controlPath = Get-FleetPath -PathType Control $Cluster
+    $f = Join-Path $controlPath "arc.json"
+    $arcConfig = Get-ArcConfig $Cluster
+    if(!$arcConfig) {
+        $arcConfig =  new-object PSCustomObject -Property $PSBoundParameters
+    }
+    else {
+        foreach($psbp in $PSBoundParameters.GetEnumerator())
+        {
+            $arcConfig.($psbp.Key) = $psbp.Value
+        }
+    }
+    # Set default values for non-mandatory fields
+    if($arcConfig.psobject.properties.match('StoragePathName').Count -eq 0) {
+        $arcConfig | Add-Member -MemberType NoteProperty -Name 'StoragePathName' -Value $StoragePathName
+    }
+    if($arcConfig.psobject.properties.match('ImageName').Count -eq 0)  {
+        $arcConfig | Add-Member -MemberType NoteProperty -Name 'ImageName' -Value $ImageName
+    }
+    if($arcConfig.psobject.properties.match('Enabled').Count -eq 0)  {
+         $arcConfig | Add-Member -MemberType NoteProperty -Name 'Enabled' -Value $Enabled  # disabled by default
+    }
+    if(!(Test-ArcConfig $arcConfig)){
+        return;
+    }
+    $generateSalt = ($arcConfig.psobject.properties.match('Salt').Count -eq 0) -or $ResetSalt
+    if($generateSalt -or $PSBoundParameters.ContainsKey("ResourceGroup")) {
+        $retry = 0;
+        while ($retry -lt 3) {
+            if($generateSalt) {
+                $salt = Get-Salt
+            }
+            else {
+                $salt = $arcConfig.Salt
+            }
+            $nodes = @(Get-ClusterNode)
+            $isValidSalt = Invoke-CommonCommand $nodes[0] -InitBlock $CommonFunc -ScriptBlock {
+               InitializeAndGetArcHCIExtendedLoc $using:arcConfig.AzureRegistrationUser $using:arcConfig.AzureRegistrationPassword $using:arcConfig.ResourceGroup
+               $vmList = az stack-hci-vm list --resource-group $using:arcConfig.ResourceGroup | ConvertFrom-Json
+               $reg = "^vm-.{1,}-" + $using:salt + "-\d{3}$"
+               $vms = $vmList | Where-Object { $_.name -match $reg}
+               if(!$vms) { return $true }
+               return false;
+            }
+            if(!$isValidSalt) {
+                $retry++
+            }
+            else {               
+                $arcConfig | Add-Member -MemberType NoteProperty -Name 'Salt' -Value $salt -Force
+                break
+            }
+        }
+        if($retry -eq 4) {
+            throw "Unable to create a unique salt with 3 retries. Pick another resource group or run Set-ArcConfig again."
+        }
+    }
+
+    $arcConfig | ConvertTo-Json | Set-Content -Path $f -Force:$true
+
+    Write-Host "Configuration updated in $f"
+}
+
+function Test-ArcConfig {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $arcConfig
+    )
+    $isValid = $true
+    $mandatoryFields = @("ResourceGroup", "AzureRegistrationUser", "AzureRegistrationPassword")
+
+    foreach ($field in $mandatoryFields) {
+         if($arcConfig.psobject.properties.match($field).Count -eq 0)
+        {
+            $isValid = $false;
+            Write-Error "$field is required."
+        }
+    }
+    return $isValid;
 }


### PR DESCRIPTION
- Adds support for arc-enabled virtual machines in Azure Stack HCI setup.
Users have the option to enable creation of Arc-enabled virtual machines using Vmfleet and run workloads on the fleet.
Documentation to use this feature added under Frameworks/VMFleet/ArcVM-Setup.md

- Adds a new command Set-FleetRunProfileScript which generates profile.xml and sets run profile template script in SMB directory.
This command will is useful especially for free runs using already available profiles (Peak, SQL, VDI etc) without having to opt into the stepped runs.

Sample command
```
 $profile = Get-FleetProfileXml -Name "VDI"
 Set-FleetRunProfileScript  -ProfileXml $profile
 ```